### PR TITLE
FIX: Fatal error: Uncaught ArgumentCountError: strpos() expects at le…

### DIFF
--- a/libs/ModulBase.php
+++ b/libs/ModulBase.php
@@ -257,7 +257,7 @@ abstract class ModulBase extends \IPSModule
         $payloadKey = self::convertIdentToPayloadKey($ident);
 
         // Umwandlung von true/false zu "ON"/"OFF" für state
-        if (strpos($payloadKey . 'state') === 0 && is_bool($value)) {
+        if (strpos($payloadKey, 'state') === 0 && is_bool($value)) {
             $value = $value ? 'ON' : 'OFF';
             $this->SendDebug(__FUNCTION__ . ' :: ' . __LINE__ . ' :: Converted boolean to state: ', $value, 0);
         }


### PR DESCRIPTION
…ast 2 arguments, 1 given in /var/lib/symcon/modules/Zigbee2MQTT/libs/ModulBase.php:260

17.10.2024, 08:59:34 | TimerPool            | Terrassentür (Update): 
Warning: 
Fatal error: Uncaught ArgumentCountError: strpos() expects at least 2 arguments, 1 given in /var/lib/symcon/modules/Zigbee2MQTT/libs/ModulBase.php:260
Stack trace:
#0 /var/lib/symcon/modules/Zigbee2MQTT/libs/ModulBase.php(260): strpos('positionstate')
#1 /-(3): Zigbee2MQTT\ModulBase->RequestAction('Z2M_Position', 100)
#2 {main}
  thrown in /var/lib/symcon/modules/Zigbee2MQTT/libs/ModulBase.php on line 260
 in /var/lib/symcon/modules/.store/de.bumaas.blindcontrol/BlindController/module.php on line 2850