### PR TITLE
Patch 20260403

### DIFF
--- a/libs/ModulBase.php
+++ b/libs/ModulBase.php
@@ -2938,32 +2938,36 @@ abstract class ModulBase extends \IPSModule
      * @see in_array()
      * @see fmod()
      */
-    private function getVariableTypeFromProfile(string $type, string $feature, $unit = '', float $value_step = 1.0, ?string $groupType = null): string
+    private function getVariableTypeFromProfile(string $type, string $feature, $unit = '', ?float $value_step = 1.0, ?string $groupType = null): string
     {
-        // Erst StandardProfile prüfen
-        foreach (self::$VariableUseStandardProfile as $profile) {
-            if ($profile['feature'] === $feature) {
-                switch ($profile['variableType']) {
-                    case VARIABLETYPE_BOOLEAN:
-                        return 'bool';
-                    case VARIABLETYPE_INTEGER:
-                        return 'int';
-                    case VARIABLETYPE_FLOAT:
-                        return 'float';
-                    case VARIABLETYPE_STRING:
-                        return 'string';
-                }
-            }
-        }
-        // Prüfen, ob ein spezifisches Mapping für type und feature existiert
+        $value_step = $value_step ?? 1.0;
+
+        // Prüfen, ob ein spezifisches Mapping existiert.
+        // Wichtig: Nicht nur auf den Feature-Namen matchen, da z.B. "position"
+        // je nach Gerätetyp numerisch (Cover) oder enum (Kontakt) sein kann.
         foreach (self::$VariableUseStandardProfile as $entry) {
-            if ((isset($entry['type']) && ($entry['type'] === $type || $entry['type'] === '')) && $entry['feature'] === $feature) {
-                $this->SendDebug(__FUNCTION__, 'Found specific mapping for type and feature: ' . $entry['variableType'], 0);
-                return $entry['variableType'];
+            if (($entry['feature'] ?? '') !== $feature) {
+                continue;
             }
-            if ((isset($entry['group_type']) && ($entry['group_type'] === $groupType || $entry['group_type'] === '')) && $entry['feature'] === $feature) {
-                $this->SendDebug(__FUNCTION__, 'Found specific mapping for group_type and feature: ' . $entry['variableType'], 0);
-                return $entry['variableType'];
+
+            $typeMatches = !isset($entry['type']) || $entry['type'] === '' || $entry['type'] === $type;
+            $groupMatches = !isset($entry['group_type']) || $entry['group_type'] === '' || $entry['group_type'] === $groupType;
+
+            if (!$typeMatches || !$groupMatches) {
+                continue;
+            }
+
+            $this->SendDebug(__FUNCTION__, 'Found specific mapping: ' . json_encode($entry), 0);
+
+            switch ($entry['variableType']) {
+                case VARIABLETYPE_BOOLEAN:
+                    return 'bool';
+                case VARIABLETYPE_INTEGER:
+                    return 'int';
+                case VARIABLETYPE_FLOAT:
+                    return 'float';
+                case VARIABLETYPE_STRING:
+                    return 'string';
             }
         }
 

--- a/libs/ModulBase.php
+++ b/libs/ModulBase.php
@@ -2284,6 +2284,8 @@ abstract class ModulBase extends \IPSModule
                     return $value;
                 }
                 if (is_string($value)) {
+                    $normalizedValue = strtoupper(trim($value, " \t\n\r\0\x0B\"'"));
+
                     // Exposes-Daten für diesen Identifier abrufen
                     $exposes = $this->ReadAttributeArray(self::ATTRIBUTE_EXPOSES);
                     foreach ($exposes as $expose) {
@@ -2295,22 +2297,26 @@ abstract class ModulBase extends \IPSModule
                                 $feature['type'] === 'binary') {
 
                                 // Prüfen ob der Wert dem value_on entspricht
-                                if ($value == $feature['value_on']) {
+                                if ($value === $feature['value_on']) {
                                     return true;
                                 }
                                 // Prüfen ob der Wert dem value_off entspricht
-                                elseif ($value == $feature['value_off']) {
+                                elseif ($value === $feature['value_off']) {
                                     return false;
                                 }
                             }
                         }
                     }
-                    // Standard ON/OFF Prüfung als Fallback
-                    if (strtoupper($value) === 'ON') {
+                    // Standardprüfung für übliche Bool-Textwerte als Fallback
+                    if (in_array($normalizedValue, ['ON', 'TRUE', 'YES', '1', 'LOCK', 'OPEN'], true)) {
                         return true;
-                    } elseif (strtoupper($value) === 'OFF') {
+                    }
+                    if (in_array($normalizedValue, ['OFF', 'FALSE', 'NO', '0', 'UNLOCK', 'CLOSE', 'CLOSED'], true)) {
                         return false;
                     }
+
+                    $this->SendDebug(__FUNCTION__, 'Unbekannter boolescher Stringwert für ' . $ident . ': ' . json_encode($value) . ' -> false', 0);
+                    return false;
                 }
                 return (bool) $value;
             case 1:


### PR DESCRIPTION
1. Fixed position type resolution
Updated getVariableTypeFromProfile() to avoid feature-name-only matching.
Mapping now requires compatible feature plus type / group_type context.
Prevents incorrect typing for ambiguous features like position (e.g. cover numeric vs enum/string devices).

2. Fixed boolean parsing for "ON" / "OFF" and similar values
Updated adjustValueByType() boolean branch:
strict comparisons (===) for value_on / value_off
normalized text handling (trim + uppercase)
explicit token mapping for common boolean strings
Prevents false positives where string values could previously be cast to true incorrectly (e.g. "OFF" edge cases).

3. UTF-8 and payload decoding cleanup
Updated payload parsing:
first decode JSON directly
only apply encoding-conversion fallback when JSON decoding fails
Removed unsafe/redundant re-encoding in unit handling:
no forced mb_convert_encoding(..., 'UTF-8', 'AUTO') for unit checks
no forced unit re-encoding when building numeric profile suffixes
Keeps unit strings stable and avoids mojibake risks.